### PR TITLE
test case unsinking 64-bit pointer + tests matrix + run-test bugix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,12 @@ env:
   - JOBS=3
   - LUAJIT_PREFIX=/opt/luajit21
   - LUAJIT_SYSM_PREFIX=/opt/luajit21-sysm
+  - LUAJIT_COMMON_XCFLAGS="-DLUA_USE_APICHECK -DLUA_USE_ASSERT -DLUAJIT_NUMMODE=2 -msse4.2 -O1"
+  matrix:
+  - LUAJIT_XCFLAGS="$LUAJIT_COMMON_XCFLAGS"
+  - LUAJIT_XCFLAGS="-DLUAJIT_ENABLE_LUA52COMPAT $LUAJIT_COMMON_XCFLAGS" LUA52=1
+  - LUAJIT_XCFLAGS="-DLUAJIT_USE_VALGRIND -DLUAJIT_USE_SYSMALLOC -DLUAJIT_ENABLE_LUA52COMPAT $LUAJIT_COMMON_XCFLAGS" LUA52=1 FLAGS=-v
+  - LUAJIT_XCFLAGS="-DLUAJIT_USE_GC64 -DLUAJIT_ENABLE_LUA52COMPAT $LUAJIT_COMMON_XCFLAGS" LUA52=1
 
 install:
   - git clone -b v2.1-agentzh https://github.com/openresty/luajit2.git ../luajit2
@@ -35,13 +41,7 @@ install:
 script:
   - valgrind --version
   - cd ../luajit2
-  - make -j$JOBS CCDEBUG=-g Q= PREFIX=$LUAJIT_PREFIX CC=$CC XCFLAGS='-DLUAJIT_ENABLE_LUA52COMPAT -DLUA_USE_APICHECK -DLUA_USE_ASSERT -DLUAJIT_NUMMODE=2 -msse4.2 -O1' > build.log 2>&1 || (cat build.log && exit 1)
+  - make -j$JOBS CCDEBUG=-g Q= PREFIX=$LUAJIT_PREFIX CC=$CC XCFLAGS="$LUAJIT_XCFLAGS" > build.log 2>&1 || (cat build.log && exit 1)
   - sudo make install PREFIX=$LUAJIT_PREFIX > build.log 2>&1 || (cat build.log && exit 1)
   - cd ../luajit2-test-suite
-  - LUA52=1 ./run-tests -j $JOBS $LUAJIT_PREFIX
-  - cd ../luajit2
-  - make clean
-  - make -j$JOBS CCDEBUG=-g Q= PREFIX=$LUAJIT_SYSM_PREFIX CC=$CC XCFLAGS='-DLUAJIT_ENABLE_LUA52COMPAT -DLUAJIT_NUMMODE=2 -DLUA_USE_APICHECK -DLUA_USE_ASSERT -DLUAJIT_USE_VALGRIND -DLUAJIT_USE_SYSMALLOC -O1 -msse4.2' > build.log 2>&1 || (cat build.log && exit 1)
-  - sudo make install PREFIX=$LUAJIT_SYSM_PREFIX > build.log 2>&1 || (cat build.log && exit 1)
-  - cd ../luajit2-test-suite
-  - LUA52=1 ./run-tests -j $JOBS -v $LUAJIT_SYSM_PREFIX
+  - ./run-tests -j $JOBS $FLAGS $LUAJIT_PREFIX

--- a/test/ffi/unsink_64_kptr.lua
+++ b/test/ffi/unsink_64_kptr.lua
@@ -1,0 +1,26 @@
+local ffi = require("ffi")
+
+local array = ffi.new("struct { int x; } [1]")
+
+-- This test forces the VM to unsink a pointer that was constructed
+-- from a constant. The IR will include a 'cnewi' instruction to
+-- allocate an FFI pointer object, the pointer value will be an IR
+-- constant, the allocation will be sunk, and the allocation will
+-- at some point be "unsunk" due to a reference in the snapshot for
+-- a taken exit.
+
+-- Note: JIT will recognize <array> as a "singleton" and allow its
+-- address to be inlined ("constified") instead of looking up the
+-- upvalue at runtime.
+
+local function fn(i)
+  local struct = array[0]   -- Load pointer that the JIT will constify.
+  if i == 1000 then end     -- Force trace exit when i==1000.
+  struct.x = 0              -- Ensure that 'struct' is live after exit.
+end
+
+-- Loop over the function to make it compile and take a trace exit
+-- during the final iteration.
+for i = 1, 1000 do
+  fn(i)
+end


### PR DESCRIPTION
Sister PR containing a test case for https://github.com/openresty/luajit2/pull/46

Also included in this PR:
* a matrix of XCFLAGS on Travis-CI, to which we added non Lua 5.2 and GC64 modes.
* a bugfix in run-tests allowing to specify individual test files as per the tool's help prompt