### PR TITLE
Adjust stackov.lua to expect "error in error handling"

### DIFF
--- a/test/misc/stackov.lua
+++ b/test/misc/stackov.lua
@@ -8,11 +8,12 @@ assert(err == false)
 
 local first = string.match(s, "[^\n]+")
 local line = debug.getinfo(f, "S").linedefined+1
-assert(string.match(first, ":"..line..": stack overflow$"))
+assert(string.match(first, ":"..line..": stack overflow$") or
+       string.match(first, "error in error handling"))
 
 local n = 1
 for _ in string.gmatch(s, "\n") do n = n + 1 end
-assert(n == 1+1+11+1+10)
+assert(n == 1+1+11+1+10 or n == 1)
 
 local function g(i)
   g(i)


### PR DESCRIPTION
As mentioned in LuaJIT/LuaJIT#618, after the fix for
LuaJIT/LuaJIT#603, stack overflows may sometimes also cause "error in
error handling" instead of a proper stack overflow error message.