### PR TITLE
tests: fix tests when jit.opt is missing

### DIFF
--- a/test/misc/iter-bug.lua
+++ b/test/misc/iter-bug.lua
@@ -1,4 +1,4 @@
 -- from Mike Pall
 
-require "jit.opt".start("maxside=0")
+if jit and jit.opt then jit.opt.start("maxside=0") end
 local t={1}; for i=1,100 do for k,v in pairs(t) do end end

--- a/test/misc/jit_record.lua
+++ b/test/misc/jit_record.lua
@@ -1,4 +1,4 @@
-require "jit.opt".start("hotloop=2", "hotexit=1", "maxsnap=9")
+if jit and jit.opt then jit.opt.start("hotloop=2", "hotexit=1", "maxsnap=9") end
 
 local m = 1
 


### PR DESCRIPTION
This is the case on ppc64le (https://github.com/openresty/luajit2/issues/178#issuecomment-2078774173).

I am not sure if the tests should be skipped completely instead.